### PR TITLE
Add cache versioning and offline fallback

### DIFF
--- a/fallback.html
+++ b/fallback.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self';">
+  <title>Offline</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { text-align: center; padding-top: 50px; }
+  </style>
+</head>
+<body>
+  <h1>You are offline</h1>
+  <p>This application requires an internet connection. Please reconnect and try again.</p>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,20 +1,37 @@
+const CACHE_VERSION = 'v2';
+const CACHE_NAME = `inventory-cache-${CACHE_VERSION}`;
+const CACHE_FILES = [
+  '/',
+  '/index.html',
+  '/owner.html',
+  '/consumer.html',
+  '/android.html',
+  '/fallback.html',
+  '/style.css',
+  '/script.js',
+  '/manifest.json'
+];
+
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open('inventory-cache-v1').then(cache => cache.addAll([
-      '/',
-      '/index.html',
-      '/owner.html',
-      '/consumer.html',
-      '/android.html',
-      '/style.css',
-      '/script.js',
-      '/manifest.json'
-    ]))
+    caches.open(CACHE_NAME).then(cache => cache.addAll(CACHE_FILES))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(names => Promise.all(
+      names.filter(name => name.startsWith('inventory-cache-') && name !== CACHE_NAME)
+           .map(name => caches.delete(name))
+    ))
   );
 });
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    caches.match(event.request).then(response => {
+      if (response) return response;
+      return fetch(event.request).catch(() => caches.match('/fallback.html'));
+    })
   );
 });


### PR DESCRIPTION
## Summary
- version service worker cache and clean up old versions
- provide fallback offline page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849a8e5595c832ba7d834a1b5887081