### PR TITLE
Move modal JS to external file

### DIFF
--- a/android.html
+++ b/android.html
@@ -51,7 +51,7 @@
                 Total: $00.00
             </div>
             <button
-                onclick="document.getElementById('paymentModal').style.display='flex'"
+                id="proceed-to-pay"
             >
                 Proceed to Pay
             </button>
@@ -60,18 +60,16 @@
         <div
             id="paymentModal"
             class="modal"
-            onclick="this.style.display='none'"
+            
         >
-            <div class="modal-content" onclick="event.stopPropagation()">
+            <div class="modal-content">
                 <span
                     class="close"
-                    onclick="document.getElementById('paymentModal').style.display='none'"
                     >✕</span
                 >
                 <p>Redirecting to payment gateway...</p>
                 <button
                     class="cancel-btn"
-                    onclick="document.getElementById('paymentModal').style.display='none'"
                 >
                     Cancel
                 </button>
@@ -87,5 +85,6 @@
             📦 Order Status: In Transit | Estimated Arrival: 2 hrs | Tracked by:
             MyLogistica
         </div>
+        <script src="js/android.js"></script>
     </body>
 </html>

--- a/js/android.js
+++ b/js/android.js
@@ -1,0 +1,39 @@
+'use strict';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const paymentModal = document.getElementById('paymentModal');
+    if (!paymentModal) return;
+
+    const openBtn = document.getElementById('proceed-to-pay');
+    const closeBtn = paymentModal.querySelector('.close');
+    const cancelBtn = paymentModal.querySelector('.cancel-btn');
+    const modalContent = paymentModal.querySelector('.modal-content');
+
+    if (openBtn) {
+        openBtn.addEventListener('click', () => {
+            paymentModal.style.display = 'flex';
+        });
+    }
+
+    if (closeBtn) {
+        closeBtn.addEventListener('click', () => {
+            paymentModal.style.display = 'none';
+        });
+    }
+
+    if (cancelBtn) {
+        cancelBtn.addEventListener('click', () => {
+            paymentModal.style.display = 'none';
+        });
+    }
+
+    if (modalContent) {
+        modalContent.addEventListener('click', (event) => {
+            event.stopPropagation();
+        });
+    }
+
+    paymentModal.addEventListener('click', () => {
+        paymentModal.style.display = 'none';
+    });
+});


### PR DESCRIPTION
## Summary
- create `js/android.js` to open and close the payment modal
- remove inline `onclick` attributes from `android.html`
- load the new script at the bottom of the page

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-prettier')*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684deb996264832b908dffff2e3c010c